### PR TITLE
sites: un-hide the "why us" section header

### DIFF
--- a/sites/content/en/__i18n.toml
+++ b/sites/content/en/__i18n.toml
@@ -24,10 +24,10 @@ Focus = false
 
 
 [i18n.WhyUs]
-ID = 'why-us'
-Title = 'Why Us?'
+ID = 'why-choose-us'
+Title = 'Why Choose Us?'
 HTML = '''
-Some good reasons for doing business with us.
+Some solid reasons for choosing us to be in your business venture.
 '''
 
 

--- a/sites/data/Business/Explore-With-Confidence.toml
+++ b/sites/data/Business/Explore-With-Confidence.toml
@@ -2,17 +2,17 @@
 ID = 'explore-with-confidence'
 Title = 'Explore With Confidence'
 HTML = '''
-<b><i>Modular Components & Backed by Time Machine Technology</i></b> — explore
-confidently and continuously improved.
+<b><i>We Got The Right Technologies</i></b> — explore your new boundaries
+without worrying about breaking things.
 '''
 Plain = '''
-**Modular Components & Backed by a Time Machine Technology** — explore
-confidently and continuously improved.
+**We Got The Right Technologies** — explore your new boundaries without worrying
+about breaking things.
 '''
 
 [[Languages.EN.CTA]]
 Value = 'https://github.com/ZORALab/demo-web-prestige/releases'
-Label = 'WITNESS LIVE HERE'
+Label = 'WITNESS CONTROLLED RELEASES LIVE'
 
 
 
@@ -21,8 +21,8 @@ Label = 'WITNESS LIVE HERE'
 Name = 'Explore with Confidence'
 Decorative = true
 Loading = 'lazy'
-Width = '600'
-Height = '420'
+Width = '800'
+Height = '560'
 CORS = 'anonymous'
 Relationship = ''
 Design = ''

--- a/sites/data/Business/Into-The-Future.toml
+++ b/sites/data/Business/Into-The-Future.toml
@@ -2,12 +2,12 @@
 ID = 'into-the-future'
 Title = 'Into The Future'
 HTML = '''
-<b><i>Supportive Maintenance Services Available</i></b> — Continue to
-collaborate beyond our project completion.
+<b><i>We Have SME Friendly Maintenance Services</i></b> — let's seek s mutual
+win-win business sustainability & outcome.
 '''
 Plain = '''
-<b><i>Supportive Maintenance Services Available</i></b> — Continue to
-collaborate beyond our project completion.
+**We Have SME Friendly Maintenance Services** — let's seek s mutual win-win
+business sustainability & outcome.
 '''
 
 [[Languages.EN.CTA]]
@@ -21,8 +21,8 @@ Label = ''
 Name = 'Into the Future'
 Decorative = true
 Loading = 'lazy'
-Width = '600'
-Height = '420'
+Width = '800'
+Height = '560'
 CORS = 'anonymous'
 Relationship = ''
 Design = ''

--- a/sites/data/Business/Prestigiously-Empowering.toml
+++ b/sites/data/Business/Prestigiously-Empowering.toml
@@ -2,17 +2,17 @@
 ID = 'prestigously-empowering'
 Title = 'Prestigously Empowering'
 HTML = '''
-<b><i>Listening to Every Tiny Bits of Your Idea, Always</i></b> — tap our
-in-depth technological knowledge and tools to materialize it.
+<b><i>Always Listening and Tracking Every Single Bits of Your Idea</i></b> —
+just express your thought; we'll dance accordingly.
 '''
 Plain = '''
-**Listening to Every Tiny Bits of Your Idea, Always** — tap into our
-in-depth technological knowledge and tools to materialize it.
+**Always Listening and Tracking Every Single Bits of Your Idea** — just express
+your thought; we'll dance accordingly.
 '''
 
 [[Languages.EN.CTA]]
-Value = 'https://github.com/ZORALab/demo-web-prestige/issues'
-Label = 'WITNESS LIVE HERE'
+Value = 'https://github.com/ZORALab/demo-web-prestige/issues?q=is%3Aissue'
+Label = 'WITNESS TRACKER SYSTEM LIVE'
 
 
 
@@ -21,8 +21,8 @@ Label = 'WITNESS LIVE HERE'
 Name = 'Prestigously Empowering'
 Decorative = true
 Loading = 'lazy'
-Width = '600'
-Height = '420'
+Width = '800'
+Height = '560'
 CORS = 'anonymous'
 Relationship = ''
 Design = ''

--- a/sites/data/Business/Reliable-Foundation.toml
+++ b/sites/data/Business/Reliable-Foundation.toml
@@ -2,17 +2,17 @@
 ID = 'reliable-foundation'
 Title = 'Reliable Foundation'
 HTML = '''
-<b><i>Configured and Backed by the Right Technologies</i></b> — grow reliably
-with the latest insights across the industry.
+<b><i>We Offers Tested and Continuously Improvable Outcome</i></b> — grow your
+already procured assets adapting to changes in time.
 '''
 Plain = '''
-**Configured and Backed by the Right Technologies Autonomously** — grow reliably
-with the latest insights across the industry.
+**We Offers Tested and Continuously Improvable Outcome** — grow your already
+procured assets adapting to changes in time.
 '''
 
 [[Languages.EN.CTA]]
 Value = 'https://github.com/orgs/ZORALab/projects/9'
-Label = 'WITNESS LIVE HERE'
+Label = 'WITNESS PLANNER LIVE'
 
 
 
@@ -21,8 +21,8 @@ Label = 'WITNESS LIVE HERE'
 Name = 'Reliable Foundation'
 Decorative = true
 Loading = 'lazy'
-Width = '600'
-Height = '420'
+Width = '800'
+Height = '560'
 CORS = 'anonymous'
 Relationship = ''
 Design = ''

--- a/sites/layouts/content/landing/index.html
+++ b/sites/layouts/content/landing/index.html
@@ -43,6 +43,8 @@ algorithms are required.
 					{{- $ret = string $ret.Output -}}
 					<a href='{{- $ret -}}' class='button
 						{{- if $v.Focus }} pill{{- end -}}
+					' style='
+						min-width: 25rem;
 					'>
 						{{- $v.Label -}}
 					</a>
@@ -65,8 +67,8 @@ algorithms are required.
 
 
 	<section id='{{- $i18n.WhyUs.ID -}}'>
-		<h2 style='opacity: 0;'>{{- $i18n.WhyUs.Title -}}</h2>
-		<p style='opacity: 0;'>{{- $i18n.WhyUs.HTML -}}</p>
+		<h2>{{- $i18n.WhyUs.Title -}}</h2>
+		<p>{{- $i18n.WhyUs.HTML -}}</p>
 
 		<div class='row' style='--grid-gap: 5rem;'>
 		{{- range $unused, $v := $Page.Data.Store.Business }}
@@ -96,6 +98,7 @@ algorithms are required.
 						--anchor-color: var(--color-contrast-200);
 						--anchor-color-focus: var(--color-primary-900);
 						--anchor-background-focus: var(--color-contrast-200);
+						margin-top: 1rem;
 					'>
 						{{- $w.Label -}}</a>
 					{{- end }}
@@ -183,13 +186,8 @@ algorithms are required.
 		'></div>
 
 
-		<h2>
-			{{- $i18n.ThisDesign.Title -}}
-		</h2>
-		<p>
-			{{- $i18n.ThisDesign.HTML -}}
-		</p>
-
+		<h2>{{- $i18n.ThisDesign.Title -}}</h2>
+		<p>{{- $i18n.ThisDesign.HTML -}}</p>
 		{{- $ret = merge $Page (dict "Input"
 			(dict "Data" $i18n.ThisDesign.Reference.Value)
 		) -}}

--- a/sites/layouts/partials/hestiaGUI/corygalynaCARD/ToCSS_VARIABLES
+++ b/sites/layouts/partials/hestiaGUI/corygalynaCARD/ToCSS_VARIABLES
@@ -40,7 +40,6 @@
 linear-gradient(to top,
 		rgba(0, 0, 0, 1),
 		rgba(0, 0, 0, .8),
-		rgba(0, 0, 0, .4),
 		rgba(0, 0, 0, 0)
 ) no-repeat
 """


### PR DESCRIPTION
Sibert provided his feedback that the page is missing "why us" section where we actually have it. This means the current design failed so badly that people are not intuitively getting it. Hence, let's un-hide it and restore to what we know it works.

This patch un-hides the "why us" section header in sites/ directory.

Reported-by: Sibertius <sibertius@gmail.com>