### PR TITLE
sites: fixed corygalynaCARD's non-centered thumbnails on small screen

### DIFF
--- a/sites/layouts/partials/hestiaGUI/corygalynaCARD/ToCSS
+++ b/sites/layouts/partials/hestiaGUI/corygalynaCARD/ToCSS
@@ -41,7 +41,7 @@ obtained from ZORALab Enterprise.
 	transition: var(--card-timing);
 }
 
-.card .thumbnail {
+.card :is(.thumbnail, picture.thumbnail img) {
 	position: absolute;
 	top: 0;
 	left: 0;
@@ -50,9 +50,10 @@ obtained from ZORALab Enterprise.
 	margin: 0;
 	padding: 0;
 
-	width: auto;
-	height: auto;
+	width: 100%;
+	height: 100%;
 
+	object-position: var(--card-thumbnail-object-position);
 	object-fit: var(--card-thumbnail-object-fit);
 
 	overflow: var(--card-thumbnail-overflow);

--- a/sites/layouts/partials/hestiaGUI/corygalynaCARD/ToCSS_VARIABLES
+++ b/sites/layouts/partials/hestiaGUI/corygalynaCARD/ToCSS_VARIABLES
@@ -22,7 +22,7 @@
 
 "--card-thumbnail-overflow" = "hidden"
 "--card-thumbnail-object-fit" = "cover"
-
+"--card-thumbnail-object-position" = "center center"
 
 
 


### PR DESCRIPTION
Appearently, the images presented by corygalynaCARD's .thumbnail class is not displaying properly (non-centered and always on the left). This is caused by browser treating 'picture > img' not the same as 'picture'. Hence, we need to fix/workaround it.

This patch fixes corygalynaCARD's non-centered thumbnails on small screen in sites/ directory.