### PR TITLE
sites: added mixed use of Sans and Serif fonts

### DIFF
--- a/sites/layouts/content/landing/components.toml
+++ b/sites/layouts/content/landing/components.toml
@@ -48,15 +48,25 @@
 #
 #        ...
 [[List]]
-Name = 'corygalynaCORE'
+Name = 'fontkaiFONT_KAISEIDECOL'
 Include = true
 Variables = []
 
 
 [[List]]
-Name = 'fontkaiFONT_KAISEIDECOL'
+Name = 'googleFONT_NOTOSANS'
 Include = true
 Variables = []
+
+
+[[List]]
+Name = 'corygalynaCORE'
+Include = true
+Variables = [
+	{ "--body-font-family" = '"Noto Sans", "Noto Serif", "Noto Color Emoji", "Roboto", "Helvetica Neue", "sans-serif"' },
+
+	{ "--headers-font-family" = '"Kaisei Decol", "Roboto", "Helvetica Neue", "sans-serif"' },
+]
 
 
 [[List]]

--- a/sites/layouts/partials/hestiaGUI/corygalynaCORE/ToCSS
+++ b/sites/layouts/partials/hestiaGUI/corygalynaCORE/ToCSS
@@ -150,6 +150,15 @@ h2, .h2,
 h3, .h3,
 h4, .h4,
 h5, .h5,
+h6, .h6 {
+	font-family: var(--headers-font-family);
+}
+
+h1, .h1,
+h2, .h2,
+h3, .h3,
+h4, .h4,
+h5, .h5,
 h6, .h6,
 p {
 	width: 100%;

--- a/sites/layouts/partials/hestiaGUI/corygalynaCORE/ToCSS_VARIABLES
+++ b/sites/layouts/partials/hestiaGUI/corygalynaCORE/ToCSS_VARIABLES
@@ -62,6 +62,7 @@
 
 # fonts
 "--body-font-family" = "\"Roboto\", \"Helvetica Neue\", \"sans-serif\""
+"--headers-font-family" = "\"Roboto\", \"Helvetica Neue\", \"sans-serif\""
 "--body-font-size" = "1.5rem"
 "--body-font-size-print" = "10pt"
 "--body-font-weight" = "normal"


### PR DESCRIPTION
Since we need to maintain the balance between the use of Sans and Serif fonts, we don't have a choice but to re-use google's Noto Sans for the easiest way out. Hence, let's do this.

This patch adds mixed use of Sans and Serif fonts in sites/ directory.