### PR TITLE
sites: 2nd content simplification re-factoring efforts

### DIFF
--- a/sites/data/Business/Into-The-Future.toml
+++ b/sites/data/Business/Into-The-Future.toml
@@ -2,12 +2,12 @@
 ID = 'into-the-future'
 Title = 'Into The Future'
 HTML = '''
-<b><i>We Have SME Friendly Maintenance Services</i></b> — let's seek s mutual
-win-win business sustainability & outcome.
+<b><i>We Have Business Friendly Maintenance Services</i></b> — let's seeks a
+mutual win-win & sustainable long term collaborations.
 '''
 Plain = '''
-**We Have SME Friendly Maintenance Services** — let's seek s mutual win-win
-business sustainability & outcome.
+**We Have Business Friendly Maintenance Services** — let's seeks a
+mutual win-win & sustainable long term collaborations.
 '''
 
 [[Languages.EN.CTA]]


### PR DESCRIPTION
After getting a pass from a granny test and feedbacks from Sibert, we have to remove the remaining acronyms and use simple English. The goal is not to make visitor to Google search terms when experiencing the entire journey. Hence, let's refactor it again.

This patch refactors the /en content with simple english in sites/ directory for the 2nd time.