### PR TITLE
sites: enhanced offline caching policy

### DIFF
--- a/sites/data/Hestia/Caches/en.toml
+++ b/sites/data/Hestia/Caches/en.toml
@@ -70,21 +70,9 @@
 #   URL = "/zh-hans"
 #   Cache = "cache-first"
 [[Contents]]
-URL = "/index.html"
+URL = "/en/index.html"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/index.json"
-Cache = "network-first"
-
-[[Contents]]
-URL = "/thumbnails-1200x630.jpg"
-Cache = "network-first"
-
-[[Contents]]
-URL = "/thumbnails-1200x1200.jpg"
-Cache = "network-first"
-
-[[Contents]]
-URL = "/thumbnails-480x480.jpg"
+URL = "/en/index.json"
 Cache = "network-first"

--- a/sites/data/Hestia/Caches/fonts-kaisei-decol.toml
+++ b/sites/data/Hestia/Caches/fonts-kaisei-decol.toml
@@ -70,21 +70,13 @@
 #   URL = "/zh-hans"
 #   Cache = "cache-first"
 [[Contents]]
-URL = "/index.html"
+URL = "/fonts/KaiseiDecol-Bold.ttf"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/index.json"
+URL = "/fonts/KaiseiDecol-Medium.ttf"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x630.jpg"
-Cache = "network-first"
-
-[[Contents]]
-URL = "/thumbnails-1200x1200.jpg"
-Cache = "network-first"
-
-[[Contents]]
-URL = "/thumbnails-480x480.jpg"
+URL = "/fonts/KaiseiDecol-Regular.ttf"
 Cache = "network-first"

--- a/sites/data/Hestia/Caches/fonts-noto-sans.toml
+++ b/sites/data/Hestia/Caches/fonts-noto-sans.toml
@@ -70,21 +70,77 @@
 #   URL = "/zh-hans"
 #   Cache = "cache-first"
 [[Contents]]
-URL = "/index.html"
+URL = "/fonts/NotoColorEmoji.ttf"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/index.json"
+URL = "/fonts/NotoSans-Black.ttf"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x630.jpg"
+URL = "/fonts/NotoSans-BlackItalic.ttf"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x1200.jpg"
+URL = "/fonts/NotoSans-Bold.ttf"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-480x480.jpg"
+URL = "/fonts/NotoSans-BoldItalic.ttf"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/fonts/NotoSans-ExtraBold.ttf"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/fonts/NotoSans-ExtraBoldItalic.ttf"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/fonts/NotoSans-ExtraLight.ttf"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/fonts/NotoSans-ExtraLightItalic.ttf"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/fonts/NotoSans-Italic.ttf"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/fonts/NotoSans-Light.ttf"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/fonts/NotoSans-LightItalic.ttf"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/fonts/NotoSans-Medium.ttf"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/fonts/NotoSans-MediumItalic.ttf"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/fonts/NotoSans-Regular.ttf"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/fonts/NotoSans-SemiBold.ttf"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/fonts/NotoSans-SemiBoldItalic.ttf"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/fonts/NotoSans-Thin.ttf"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/fonts/NotoSans-ThinItalic.ttf"
 Cache = "network-first"

--- a/sites/data/Hestia/Caches/img-backgrounds-explore-with-confidences.toml
+++ b/sites/data/Hestia/Caches/img-backgrounds-explore-with-confidences.toml
@@ -70,21 +70,37 @@
 #   URL = "/zh-hans"
 #   Cache = "cache-first"
 [[Contents]]
-URL = "/index.html"
+URL = "/img/backgrounds/explore-with-confidence-1024x717.avif"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/index.json"
+URL = "/img/backgrounds/explore-with-confidence-1024x717.webp"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x630.jpg"
+URL = "/img/backgrounds/explore-with-confidence-1024x717.jpg"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x1200.jpg"
+URL = "/img/backgrounds/explore-with-confidence-800x560.avif"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-480x480.jpg"
+URL = "/img/backgrounds/explore-with-confidence-800x560.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/explore-with-confidence-800x560.jpg"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/explore-with-confidence-500x350.avif"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/explore-with-confidence-500x350.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/explore-with-confidence-500x350.jpg"
 Cache = "network-first"

--- a/sites/data/Hestia/Caches/img-backgrounds-friendly-discussion-platform.toml
+++ b/sites/data/Hestia/Caches/img-backgrounds-friendly-discussion-platform.toml
@@ -70,21 +70,13 @@
 #   URL = "/zh-hans"
 #   Cache = "cache-first"
 [[Contents]]
-URL = "/index.html"
+URL = "/img/backgrounds/friendly-discussion-platform-2048x1075.avif"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/index.json"
+URL = "/img/backgrounds/friendly-discussion-platform-2048x1075.webp"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x630.jpg"
-Cache = "network-first"
-
-[[Contents]]
-URL = "/thumbnails-1200x1200.jpg"
-Cache = "network-first"
-
-[[Contents]]
-URL = "/thumbnails-480x480.jpg"
+URL = "/img/backgrounds/friendly-discussion-platform-2048x1075.jpg"
 Cache = "network-first"

--- a/sites/data/Hestia/Caches/img-backgrounds-into-the-future.toml
+++ b/sites/data/Hestia/Caches/img-backgrounds-into-the-future.toml
@@ -70,21 +70,37 @@
 #   URL = "/zh-hans"
 #   Cache = "cache-first"
 [[Contents]]
-URL = "/index.html"
+URL = "/img/backgrounds/into-the-future-1024x717.avif"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/index.json"
+URL = "/img/backgrounds/into-the-future-1024x717.webp"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x630.jpg"
+URL = "/img/backgrounds/into-the-future-1024x717.jpg"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x1200.jpg"
+URL = "/img/backgrounds/into-the-future-800x560.avif"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-480x480.jpg"
+URL = "/img/backgrounds/into-the-future-800x560.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/into-the-future-800x560.jpg"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/into-the-future-500x350.avif"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/into-the-future-500x350.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/into-the-future-500x350.jpg"
 Cache = "network-first"

--- a/sites/data/Hestia/Caches/img-backgrounds-landing.toml
+++ b/sites/data/Hestia/Caches/img-backgrounds-landing.toml
@@ -70,21 +70,109 @@
 #   URL = "/zh-hans"
 #   Cache = "cache-first"
 [[Contents]]
-URL = "/index.html"
+URL = "/img/backgrounds/landing-01-4912x4912.avif"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/index.json"
+URL = "/img/backgrounds/landing-01-4912x4912.webp"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x630.jpg"
+URL = "/img/backgrounds/landing-01-4912x4912.jpg"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x1200.jpg"
+URL = "/img/backgrounds/landing-01-2048x2048.avif"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-480x480.jpg"
+URL = "/img/backgrounds/landing-01-2048x2048.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-01-2048x2048.jpg"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-01-1200x1200.avif"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-01-1200x1200.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-01-1200x1200.jpg"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-02-4912x4912.avif"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-02-4912x4912.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-02-4912x4912.jpg"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-02-2048x2048.avif"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-02-2048x2048.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-02-2048x2048.jpg"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-02-1200x1200.avif"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-02-1200x1200.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-02-1200x1200.jpg"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-03-4912x4912.avif"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-03-4912x4912.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-03-4912x4912.jpg"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-03-2048x2048.avif"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-03-2048x2048.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-03-2048x2048.jpg"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-03-1200x1200.avif"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-03-1200x1200.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/landing-03-1200x1200.jpg"
 Cache = "network-first"

--- a/sites/data/Hestia/Caches/img-backgrounds-plain-white-pantry.toml
+++ b/sites/data/Hestia/Caches/img-backgrounds-plain-white-pantry.toml
@@ -70,21 +70,13 @@
 #   URL = "/zh-hans"
 #   Cache = "cache-first"
 [[Contents]]
-URL = "/index.html"
+URL = "/img/backgrounds/plain-white-pantry-2048x1075.avif"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/index.json"
+URL = "/img/backgrounds/plain-white-pantry-2048x1075.webp"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x630.jpg"
-Cache = "network-first"
-
-[[Contents]]
-URL = "/thumbnails-1200x1200.jpg"
-Cache = "network-first"
-
-[[Contents]]
-URL = "/thumbnails-480x480.jpg"
+URL = "/img/backgrounds/plain-white-pantry-2048x1075.jpg"
 Cache = "network-first"

--- a/sites/data/Hestia/Caches/img-backgrounds-prestigously-empowering.toml
+++ b/sites/data/Hestia/Caches/img-backgrounds-prestigously-empowering.toml
@@ -70,21 +70,37 @@
 #   URL = "/zh-hans"
 #   Cache = "cache-first"
 [[Contents]]
-URL = "/index.html"
+URL = "/img/backgrounds/prestigously-empowering-1024x717.avif"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/index.json"
+URL = "/img/backgrounds/prestigously-empowering-1024x717.webp"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x630.jpg"
+URL = "/img/backgrounds/prestigously-empowering-1024x717.jpg"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x1200.jpg"
+URL = "/img/backgrounds/prestigously-empowering-800x560.avif"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-480x480.jpg"
+URL = "/img/backgrounds/prestigously-empowering-800x560.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/prestigously-empowering-800x560.jpg"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/prestigously-empowering-500x350.avif"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/prestigously-empowering-500x350.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/prestigously-empowering-500x350.jpg"
 Cache = "network-first"

--- a/sites/data/Hestia/Caches/img-backgrounds-reliable-foundation.toml
+++ b/sites/data/Hestia/Caches/img-backgrounds-reliable-foundation.toml
@@ -70,21 +70,37 @@
 #   URL = "/zh-hans"
 #   Cache = "cache-first"
 [[Contents]]
-URL = "/index.html"
+URL = "/img/backgrounds/reliable-foundation-1024x717.avif"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/index.json"
+URL = "/img/backgrounds/reliable-foundation-1024x717.webp"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x630.jpg"
+URL = "/img/backgrounds/reliable-foundation-1024x717.jpg"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x1200.jpg"
+URL = "/img/backgrounds/reliable-foundation-800x560.avif"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-480x480.jpg"
+URL = "/img/backgrounds/reliable-foundation-800x560.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/reliable-foundation-800x560.jpg"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/reliable-foundation-500x350.avif"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/reliable-foundation-500x350.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/backgrounds/reliable-foundation-500x350.jpg"
 Cache = "network-first"

--- a/sites/data/Hestia/Caches/img-brands.toml
+++ b/sites/data/Hestia/Caches/img-brands.toml
@@ -70,21 +70,25 @@
 #   URL = "/zh-hans"
 #   Cache = "cache-first"
 [[Contents]]
-URL = "/index.html"
+URL = "/img/brands/cloudflare-1200x630.svg"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/index.json"
+URL = "/img/brands/github-1200x630.svg"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x630.jpg"
+URL = "/img/brands/google-analytics-4-1200x630.svg"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x1200.jpg"
+URL = "/img/brands/hugo-1200x630.svg"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-480x480.jpg"
+URL = "/img/brands/prestige-animated-1200x335.svg"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/brands/zoralab-1200x630.svg"
 Cache = "network-first"

--- a/sites/data/Hestia/Caches/img-icons.toml
+++ b/sites/data/Hestia/Caches/img-icons.toml
@@ -70,21 +70,25 @@
 #   URL = "/zh-hans"
 #   Cache = "cache-first"
 [[Contents]]
-URL = "/index.html"
+URL = "/img/icons/app-install-1200x1200.svg"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/index.json"
+URL = "/img/icons/ci-1200x1200.svg"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x630.jpg"
+URL = "/img/icons/network-1200x1200.svg"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x1200.jpg"
+URL = "/img/icons/reasonable-price-1200x1200.svg"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-480x480.jpg"
+URL = "/img/icons/responsive-design-1200x1200.svg"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/icons/searchable-1200x1200.svg"
 Cache = "network-first"

--- a/sites/data/Hestia/Caches/img-portraits-cory-galyna.toml
+++ b/sites/data/Hestia/Caches/img-portraits-cory-galyna.toml
@@ -70,21 +70,37 @@
 #   URL = "/zh-hans"
 #   Cache = "cache-first"
 [[Contents]]
-URL = "/index.html"
+URL = "/img/portraits/cory-galyna-1200x1200.avif"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/index.json"
+URL = "/img/portraits/cory-galyna-1200x1200.webp"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x630.jpg"
+URL = "/img/portraits/cory-galyna-1200x1200.jpg"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x1200.jpg"
+URL = "/img/portraits/cory-galyna-480x480.avif"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-480x480.jpg"
+URL = "/img/portraits/cory-galyna-480x480.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/portraits/cory-galyna-480x480.jpg"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/portraits/cory-galyna-220x220.avif"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/portraits/cory-galyna-220x220.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/portraits/cory-galyna-220x200.jpg"
 Cache = "network-first"

--- a/sites/data/Hestia/Caches/img-portraits-hollowaykeanho.toml
+++ b/sites/data/Hestia/Caches/img-portraits-hollowaykeanho.toml
@@ -70,21 +70,37 @@
 #   URL = "/zh-hans"
 #   Cache = "cache-first"
 [[Contents]]
-URL = "/index.html"
+URL = "/img/portraits/hollowaykeanho-1200x1200.avif"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/index.json"
+URL = "/img/portraits/hollowaykeanho-1200x1200.webp"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x630.jpg"
+URL = "/img/portraits/hollowaykeanho-1200x1200.jpg"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x1200.jpg"
+URL = "/img/portraits/hollowaykeanho-480x480.avif"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-480x480.jpg"
+URL = "/img/portraits/hollowaykeanho-480x480.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/portraits/hollowaykeanho-480x480.jpg"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/portraits/hollowaykeanho-220x220.avif"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/portraits/hollowaykeanho-220x220.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/portraits/hollowaykeanho-220x200.jpg"
 Cache = "network-first"

--- a/sites/data/Hestia/Caches/img-portraits-max-rahubovskiy.toml
+++ b/sites/data/Hestia/Caches/img-portraits-max-rahubovskiy.toml
@@ -70,21 +70,37 @@
 #   URL = "/zh-hans"
 #   Cache = "cache-first"
 [[Contents]]
-URL = "/index.html"
+URL = "/img/portraits/max-rahubovskiy-1200x1200.avif"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/index.json"
+URL = "/img/portraits/max-rahubovskiy-1200x1200.webp"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x630.jpg"
+URL = "/img/portraits/max-rahubovskiy-1200x1200.jpg"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x1200.jpg"
+URL = "/img/portraits/max-rahubovskiy-480x480.avif"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-480x480.jpg"
+URL = "/img/portraits/max-rahubovskiy-480x480.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/portraits/max-rahubovskiy-480x480.jpg"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/portraits/max-rahubovskiy-220x220.avif"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/portraits/max-rahubovskiy-220x220.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/portraits/max-rahubovskiy-220x200.jpg"
 Cache = "network-first"

--- a/sites/data/Hestia/Caches/img-portraits-sibertius.toml
+++ b/sites/data/Hestia/Caches/img-portraits-sibertius.toml
@@ -70,21 +70,37 @@
 #   URL = "/zh-hans"
 #   Cache = "cache-first"
 [[Contents]]
-URL = "/index.html"
+URL = "/img/portraits/sibertius-1200x1200.avif"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/index.json"
+URL = "/img/portraits/sibertius-1200x1200.webp"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x630.jpg"
+URL = "/img/portraits/sibertius-1200x1200.jpg"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-1200x1200.jpg"
+URL = "/img/portraits/sibertius-480x480.avif"
 Cache = "network-first"
 
 [[Contents]]
-URL = "/thumbnails-480x480.jpg"
+URL = "/img/portraits/sibertius-480x480.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/portraits/sibertius-480x480.jpg"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/portraits/sibertius-220x220.avif"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/portraits/sibertius-220x220.webp"
+Cache = "network-first"
+
+[[Contents]]
+URL = "/img/portraits/sibertius-220x200.jpg"
 Cache = "network-first"


### PR DESCRIPTION
Right now, the offline caching policy is relying on client-side viewership to cache the required files. This is not ideal especially for a demo app. Hence, we need to enhance it with explicit policy listing. Let's do this.

This patch enhances offline caching policy in sites/ directory.